### PR TITLE
Latest GKE version, private key written to disk, no more master verbiage

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -27,3 +27,9 @@ output "Worker_Node_Tags" {
   value       = packet_device.worker_nodes.*.tags
   description = "Worker Node Tags"
 }
+
+output "ssh_key_lcation" {
+  value       = local_file.cluster_private_key_pem.filename
+  description = "The SSH Private Key File Location"
+}
+

--- a/templates/deploy_cluster.sh
+++ b/templates/deploy_cluster.sh
@@ -30,6 +30,7 @@ CLUSTER_NAME="${cluster_name}"
 ./bmctl create config -c $CLUSTER_NAME
 
 # Replace variables in cluster config
+sed -i "/Node pool configuration is only valid for 'bundled' LB mode./,+4 d" /root/baremetal/bmctl-workspace/$CLUSTER_NAME/$CLUSTER_NAME.yaml
 sed -i "s|<path to GCR service account key>|/root/baremetal/keys/gcr.json|g" /root/baremetal/bmctl-workspace/$CLUSTER_NAME/$CLUSTER_NAME.yaml
 sed -i "s|<path to SSH private key, used for node access>|/root/.ssh/id_rsa|g" /root/baremetal/bmctl-workspace/$CLUSTER_NAME/$CLUSTER_NAME.yaml
 sed -i "s|<path to Connect agent service account key>|/root/baremetal/keys/connect.json|g" /root/baremetal/bmctl-workspace/$CLUSTER_NAME/$CLUSTER_NAME.yaml

--- a/templates/update_cluster_vars.py
+++ b/templates/update_cluster_vars.py
@@ -4,18 +4,18 @@ import os
 
 # Terraform VARs
 PRIV_SUBNET = '${private_subnet}'
-NUM_MASTERS = ${master_count}
+NUM_CPS = ${cp_count}
 NUM_WORKERS = ${worker_count}
 CLUSTER_NAME = '${cluster_name}'
 
-num_total = NUM_MASTERS + NUM_WORKERS
-master_string = ''
+num_total = NUM_CPS + NUM_WORKERS
+cp_string = ''
 worker_string = ''
 
-for i in range(0, NUM_MASTERS):
-    master_string += "      - address: {}\n".format(list(ipaddress.ip_network(PRIV_SUBNET).hosts())[i].compressed)
+for i in range(0, NUM_CPS):
+    cp_string += "      - address: {}\n".format(list(ipaddress.ip_network(PRIV_SUBNET).hosts())[i].compressed)
 
-for i in range(NUM_MASTERS, num_total):
+for i in range(NUM_CPS, num_total):
     worker_string += "  - address: {}\n".format(list(ipaddress.ip_network(PRIV_SUBNET).hosts())[i].compressed)
 
 cluster_vip = list(ipaddress.ip_network(PRIV_SUBNET).hosts())[-1].compressed
@@ -26,7 +26,7 @@ lb_vip_range = "{}-{}".format(lb_vip_start, lb_vip_end)
 
 file_path = "/root/baremetal/bmctl-workspace/{0}/{0}.yaml".format(CLUSTER_NAME)
 # String Replacements
-os.system("sed -i 's|      - address: <Machine 1 IP>|{}|g' {}".format(master_string,
+os.system("sed -i 's|      - address: <Machine 1 IP>|{}|g' {}".format(cp_string,
           file_path).encode("unicode_escape").decode("utf-8"))
 os.system("sed -i 's|  - address: <Machine 2 IP>|{}|g' {}".format(worker_string,
           file_path).encode("unicode_escape").decode("utf-8"))

--- a/versions.tf
+++ b/versions.tf
@@ -15,6 +15,9 @@ terraform {
     tls = {
       source = "hashicorp/tls"
     }
+    local = {
+      source = "hashicorp/local"
+    }
   }
   required_version = ">= 0.13"
 }


### PR DESCRIPTION
- This has been updated to `0.7.0-gke.4`
- The SSH Private key is now written to `~/.ssh/<unique_name>`
- All of the verbiage for `master` has been changed to `cp` or `control-plane`